### PR TITLE
chore: django jazzmin으로 admin 페이지 수정(추후 필요 시 custom 가능)

### DIFF
--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -6,6 +6,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 Django==4.1.2
 django-dotenv==1.4.2
+django-jazzmin==2.5.0
 djangorestframework==3.14.0
 drf-yasg==1.21.4
 idna==3.4

--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -33,6 +33,7 @@ ALLOWED_HOSTS = ["*"]
 # Application definition
 
 INSTALLED_APPS = [
+    "jazzmin",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -152,4 +153,11 @@ LOGGING = {
             'level': 'DEBUG',
         },
     },
+}
+
+
+JAZZMIN_SETTINGS = {
+    'site_title': 'Daesin',
+    'site_header': 'Daesin',
+    'site_brand': 'Daesin',
 }


### PR DESCRIPTION
## 개요
- django jazzmin 설정

## 작업사항
- django admin 페이지를 커스텀 할 수 있는 extention 입니다. 기본 admin 페이지보다 가시성이 좋아서 설정했습니다.
- collectstatic 한번하시고 admin 페이지 들어가시면 잘 반영 됩니다 :)

