### PR TITLE
Feature/45 login fix

### DIFF
--- a/webapp/user/admin.py
+++ b/webapp/user/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
-from user.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 admin.site.register(User)

--- a/webapp/user/serializers.py
+++ b/webapp/user/serializers.py
@@ -1,6 +1,7 @@
 from dj_rest_auth.registration.serializers import RegisterSerializer
 from rest_framework import serializers
-from user.models import User
+from django.contrib.auth import get_user_model
+User = get_user_model()
 
 
 class CustomRegisterSerializer(RegisterSerializer):

--- a/webapp/webapp/settings.py
+++ b/webapp/webapp/settings.py
@@ -109,6 +109,8 @@ ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1
 # 이메일 제목
 ACCOUNT_EMAIL_SUBJECT_PREFIX = "[daesin]"
 
+# 로그인시 이메일빼고 아이디/비번만 사용하도록
+ACCOUNT_AUTHENTICATION_METHOD = 'username'
 
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': timedelta(hours=2),


### PR DESCRIPTION
## 개요
- 로그인시 이메일없이 아이디/비밀번호만 사용하도록 변경

## 작업사항
- ACCOUNT_AUTHENTICATION_METHOD = 'username'를 추가했다.

## 변경로직
- dj_rest_auth의 LoginSerializer의 get_auth_user_using_allauth()이 _validate_username으로 분기되도록 settings.py에 관련 설정을 추가해줬다.